### PR TITLE
Add fields for first and last name

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,8 @@ class Users(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
     given_name = db.Column(db.String(80), nullable=False)
+    first_name = db.Column(db.String(80), nullable=False)
+    last_name = db.Column(db.String(80), nullable=False)
 
 class Posts(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -40,22 +42,22 @@ def api_index():
 @app.route('/api/users', methods=['GET'])
 def api_list_users():
     users = Users.query.all()
-    return jsonify({"users": [{"id": user.id, "username": user.username, "given_name": user.given_name} for user in users]})
+    return jsonify({"users": [{"id": user.id, "username": user.username, "given_name": f"{user.first_name} {user.last_name}"} for user in users]})
 
 @app.route('/api/users', methods=['POST'])
 def api_create_user():
     json_data = request.json
 
-    user = Users(username=json_data['username'], given_name=json_data['given_name'])
+    user = Users(username=json_data['username'], given_name=json_data['given_name'], first_name=json_data['given_name'].split()[0], last_name=json_data['given_name'].split()[1])
     db.session.add(user)
     db.session.commit()
 
-    return jsonify({"user": {"id": user.id, "username": user.username, "given_name": user.given_name}})
+    return jsonify({"user": {"id": user.id, "username": user.username, "given_name": f"{user.first_name} {user.last_name}"}})
 
 @app.route('/api/users/<user_id>', methods=['GET'])
 def api_get_user(user_id):
     user = Users.query.filter_by(id=user_id).first()
-    return jsonify({"user": {"id": user.id, "username": user.username, "given_name": user.given_name}})
+    return jsonify({"user": {"id": user.id, "username": user.username, "given_name": f"{user.first_name} {user.last_name}"}})
 
 ### main ###
 

--- a/migrations/versions/v1_1_0_add_user_fields.py
+++ b/migrations/versions/v1_1_0_add_user_fields.py
@@ -1,0 +1,21 @@
+from alembic import op
+import sqlalchemy as sa
+
+# Revision identifiers, used by Alembic.
+revision = 'v1.1.0'
+down_revision = None
+
+def upgrade():
+    # Commands to apply the upgrade:
+    op.add_column('users', sa.Column('first_name', sa.String(length=80), nullable=True)) # Must be nullable to be backwards compatible
+    op.add_column('users', sa.Column('last_name', sa.String(length=80), nullable=True)) # Must be nullable to be backwards compatible
+
+    op.execute("""
+        UPDATE users
+        SET first_name = split_part(given_name, ' ', 1), last_name = split_part(given_name, ' ', 2)
+    """)
+
+def downgrade():
+    # Commands to revert the upgrade:
+    op.drop_column('users', 'first_name')
+    op.drop_column('users', 'last_name')

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -15,7 +15,7 @@ variable "blue_active" {
 
 variable "green_active" {
   type    = bool
-  default = false
+  default = true
 }
 
 variable "blue_tag" {
@@ -25,5 +25,5 @@ variable "blue_tag" {
 
 variable "green_tag" {
   type    = string
-  default = "v1.0.0"
+  default = "v1.1.0"
 }


### PR DESCRIPTION
This PR is the first of two to change the `given_name` field into two fields named `first_name` and `last_name`

In this first PR, we are safely creating and populating the new fields, while maintaining full backwards compatibility.  This can be seen because we are running two version of the application at the same time, a "blue" on `v1.0.0` and "green" on `v1.1.0` with the additions.

To test this, we need to set up the original state with main, then add the additions.

### Set up initial state with main

Build and tag the original code from `v1.0.0` for blue with the following command:
```
git checkout v1.0.0
docker build \
    -f build/release-management-examples/Dockerfile \
    -t release-management-examples:$(git describe --exact-match --tags) \
    .
```

With this built, deploy them into your kubernetes environment using the terraform provided in the `tf` directory.  Because only blue is active on `main`, only blue will deploy.

Once built, let's port forward so we can test.  The pod name will differ and should be retrieved from your kubernetes environment
```
kubectl port-forward release-management-examples-blue-646846c9b5-22khv 5003:5003
```

Let's use the API to create a user for testing
```
curl localhost:5003/api/users -XPOST -d '{"username": "truppert", "given_name": "Tyler Ruppert"}' -H "Content-Type: application/json"
```

We can see that it exists:
```
curl localhost:5003/api/users

{"users":[{"given_name":"Tyler Ruppert","id":1,"username":"truppert"}]}
```

### Build and deploy the new code

Checkout this branch (tagged v1.1.0) and build and tag as `v1.1.0` for green with the following command:
```
git checkout v1.1.0
docker build \
    -f build/release-management-examples/Dockerfile \
    -t release-management-examples:$(git describe --exact-match --tags) \
    .
```

Before applying the terraform with the new version, we should run the db migration.  This is safe to run and will support both the original (`main`) and new (`feature/rename-db-field`) versions

To do this, we need to port forward to our postgres instance in k8s:
```
kubectl port-forward service/postgres-5432 5432:5432
```

Then run the upgrade
```
flask db upgrade
```

### Testing blue and green

Let's port-forward to both blue and green so we can test individually.  We'll use port `5003` for blue and `5004` for green. 
 The pod name will differ and should be retrieved from your kubernetes environment
```
kubectl port-forward release-management-examples-blue-646846c9b5-22khv 5003:5003
kubectl port-forward release-management-examples-green-6fdd9fd587-l898h 5004:5003
```

We can now test retrieving and creating users against each with the following commands:
```
curl localhost:5003/api/users -XPOST -d '{"username": "truppertblue", "given_name": "Tyler Ruppert"}' -H "Content-Type: application/json"
curl localhost:5004/api/users -XPOST -d '{"username": "truppertgreen", "given_name": "Tyler Ruppert"}' -H "Content-Type: application/json"
curl localhost:5003/api/users
curl localhost:5004/api/users
```