### PR TITLE
Ensure new fields are fully populated

### DIFF
--- a/migrations/versions/v1_2_0_populate_new_user_fields.py
+++ b/migrations/versions/v1_2_0_populate_new_user_fields.py
@@ -1,0 +1,20 @@
+from alembic import op
+import sqlalchemy as sa
+
+# Revision identifiers, used by Alembic.
+revision = 'v1.2.0'
+down_revision = 'v1.1.0'
+
+def upgrade():
+    op.execute("""
+        UPDATE users
+        SET first_name = split_part(given_name, ' ', 1), last_name = split_part(given_name, ' ', 2)
+    """)
+
+    op.alter_column('users', 'first_name', nullable=False)
+    op.alter_column('users', 'last_name', nullable=False)
+
+def downgrade():
+    # Commands to revert the upgrade:
+    op.alter_column('users', 'first_name', nullable=True)
+    op.alter_column('users', 'last_name', nullable=True)


### PR DESCRIPTION
While in transition, Blue at `v1.0.0` was not populating the new fields created with `v1.1.0`.  This syncs the values now that both blue and green are on `v1.1.0`