### PR TITLE
Version bump to v1.2.0

### DIFF
--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -25,5 +25,5 @@ variable "blue_tag" {
 
 variable "green_tag" {
   type    = string
-  default = "v1.1.0"
+  default = "v1.2.0"
 }


### PR DESCRIPTION
Forgotten in previous PR

Now that we have all the code working correctly, we can bump Green to the new version and deploy.  This will make the old field `given_name` fully no-longer used.  We can test with green, then update blue later